### PR TITLE
Use fixed alpha value for simulations and inference

### DIFF
--- a/compute_A_eta.py
+++ b/compute_A_eta.py
@@ -21,19 +21,22 @@ if __package__ is None or __package__ == "":
     from compute_norm_acc.mock_generator.lens_solver import solve_single_lens
     from compute_norm_acc.mock_generator.lens_model import LensModel
     from compute_norm_acc.utils import selection_function
-    from compute_norm_acc.config import OBS_SCATTER_MAG
+    from compute_norm_acc.config import OBS_SCATTER_MAG, LOGALPHA_SPS
 else:
     from .mock_generator.mass_sampler import generate_samples, MODEL_PARAMS
     from .mock_generator.lens_solver import solve_single_lens
     from .mock_generator.lens_model import LensModel
     from .utils import selection_function
-    from .config import OBS_SCATTER_MAG
+    from .config import OBS_SCATTER_MAG, LOGALPHA_SPS
 
 
 def sample_lens_population(n_samples, zl=0.3, zs=2.0):
     """Generate lens population samples consistent with existing simulation."""
     data = generate_samples(n_samples)
-    logalpha_sps = np.random.normal(0.1, 0.05, n_samples)
+    # ``alpha_sps`` was previously sampled from a normal distribution.  We now
+    # adopt a fixed value configured globally to remove this source of
+    # stochasticity.
+    logalpha_sps = np.full(n_samples, LOGALPHA_SPS)
     logM_star = data["logM_star_sps"] + logalpha_sps
     logRe = data["logRe"]
     beta = np.random.rand(n_samples) ** 0.5
@@ -93,8 +96,6 @@ def ms_distribution(ms_grid, alpha_s=-1.3, ms_star=24.5):
     # if not (
     #     12.0 < mu0 < 14.0
     #     and 0 < sigmaDM < 1
-    #     and 0. < sigma_alpha < 1
-    #     and -0.3 < mu_alpha < 0.5
     #     and 0 < beta < 5
     # ):
 

--- a/config.py
+++ b/config.py
@@ -4,3 +4,10 @@
 OBS_SCATTER_STAR: float = 0.1
 OBS_SCATTER_MAG: float = 0.1
 
+# Fixed value of ``log10(alpha_sps)`` used throughout the simulation.
+#
+# Previously the mass-to-light ratio ``alpha_sps`` was drawn from a normal
+# distribution for each mock lens.  For the simplified inference workflow we
+# instead adopt a single deterministic value which can be adjusted here.
+LOGALPHA_SPS: float = 0.1
+

--- a/main.py
+++ b/main.py
@@ -32,18 +32,24 @@ def main() -> None:
     grids = precompute_grids(mock_observed_data, logMh_grid, sigma_m=scatter)
     nsteps = 5000
     # Run MCMC sampling for 10000 steps
-    sampler = run_mcmc(grids, logM_sps_obs, nsteps=nsteps, nwalkers=20,
-                       initial_guess = np.array([12.6, 1.6, 0.3, 0., 0.0]),
-        backend_file="chains_eta_new_stage7.h5"
-                        , parallel=True, nproc=mp.cpu_count()-3)
+    sampler = run_mcmc(
+        grids,
+        logM_sps_obs,
+        nsteps=nsteps,
+        nwalkers=20,
+        initial_guess=np.array([12.6, 1.6, 0.3]),
+        backend_file="chains_eta_new_stage7.h5",
+        parallel=True,
+        nproc=mp.cpu_count() - 3,
+    )
     chain = sampler.get_chain(discard=nsteps-2000, flat=True)
     print("MCMC sampling completed.")
 
     samples = chain.reshape(-1, chain.shape[-1])
 
     # 转为 DataFrame 并加上列名
-    # param_names = ["param1", "param2", "param3", "param4", "param5"]  # 你可以改成实际参数名
-    param_names = [ r"$\mu_{DM0}$", r"$\beta_{DM}$", r"$\sigma_{DM}$", r"$\mu_\alpha$", r"$\sigma_\alpha$" ]  # Example parameter names
+    # param_names = ["param1", "param2", "param3"]  # 你可以改成实际参数名
+    param_names = [r"$\mu_{DM0}$", r"$\beta_{DM}$", r"$\sigma_{DM}$"]  # Example parameter names
 
     df_samples = pd.DataFrame(samples, columns=param_names)
 
@@ -57,7 +63,7 @@ def main() -> None:
     # )
 
     # 真值
-    true_values = [12.91, 2.04, 0.37, 0.1, 0.05]
+    true_values = [12.91, 2.04, 0.37]
 
     # 绘制 pairplot
     g = sns.pairplot(

--- a/mock_generator/mock_generator.py
+++ b/mock_generator/mock_generator.py
@@ -3,6 +3,7 @@ import pandas as pd
 from .lens_properties import observed_data
 from tqdm import tqdm
 from .mass_sampler import generate_samples
+from ..config import LOGALPHA_SPS
 
 # SPS PARAMETER
 # M_star = alpha_sps * M_sps
@@ -85,9 +86,11 @@ def run_mock_simulation(
     m_s_star=24.5,
 ):
     beta_samp = np.random.rand(n_samples)**0.5
-    # alpha_sps = np.random.normal(loc=1.2, scale=0.2, size=n_samples)
-    # logalpha_sps_sample = np.log10(alpha_sps)
-    logalpha_sps_sample = np.random.normal(loc=0.1, scale=0.05, size=n_samples)  # Example logalpha_sps
+    # ``logalpha_sps_sample`` was previously drawn from a normal distribution
+    # to mimic scatter in the stellar mass-to-light ratio.  The simplified
+    # treatment adopted here uses a single fixed value, configured globally in
+    # :mod:`config`.
+    logalpha_sps_sample = np.full(n_samples, LOGALPHA_SPS)
     samples = generate_samples(n_samples, alpha_s=alpha_s, m_s_star=m_s_star)
 
     if process is None or process == 0:

--- a/run_mcmc.py
+++ b/run_mcmc.py
@@ -44,8 +44,8 @@ def run_mcmc(
     nwalkers, nsteps:
         MCMC configuration.
     initial_guess:
-        Initial position of the walkers in parameter space.  Must have length 5
-        corresponding to ``(mu0, beta, sigmaDM, mu_alpha, sigma_alpha)``.
+        Initial position of the walkers in parameter space.  Must have length 3
+        corresponding to ``(mu0, beta, sigmaDM)``.
     backend_file:
         Filename or path for the HDF5 backend.  If a relative path is
         supplied, the file will be placed inside the ``chains`` directory.  The
@@ -83,9 +83,9 @@ def run_mcmc(
     # return sampler
 
 
-    ndim = 5
+    ndim = 3
     if initial_guess is None:
-        initial_guess = np.array([12.5, 2.0, 0.3, 0.1, 0.1])
+        initial_guess = np.array([12.5, 2.0, 0.3])
 
     # === 使用 pathlib 构建路径 ===
     base_dir = Path(__file__).parent.resolve()


### PR DESCRIPTION
## Summary
- Add `LOGALPHA_SPS` configuration and use it instead of sampling alpha from a normal distribution
- Simplify mock data generation, A-eta computation, and likelihood to treat alpha as fixed
- Reduce MCMC parameter space to `(mu0, beta, sigmaDM)` and update scripts accordingly

## Testing
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6894436a7440832d84f638f9ebb3eb4e